### PR TITLE
Use raw description when building scheduled post card

### DIFF
--- a/.github/workflows/scheduled_posts.yml
+++ b/.github/workflows/scheduled_posts.yml
@@ -71,8 +71,7 @@ EOF
 
           # Inject dynamic values
           sed -i "s#TITLE_PLACEHOLDER#$(printf '%s' "$title" | sed 's/[&/]/\\&/g')#" card_snippet.html
-          desc_html="$(printf '%s' "$description" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')"
-          sed -i "s#DESCRIPTION_PLACEHOLDER#$(printf '%s' "$desc_html" | sed 's/[&/]/\\&/g')#" card_snippet.html
+          sed -i "s#DESCRIPTION_PLACEHOLDER#$(printf '%s' "$description" | sed 's/[&/]/\\&/g')#" card_snippet.html
           sed -i "s#FILENAME_PLACEHOLDER#$(printf '%s' "$filename" | sed 's/[&/]/\\&/g')#" card_snippet.html
 
       - name: Stop if no draft


### PR DESCRIPTION
## Summary
- stop converting draft descriptions to HTML entities when building card_snippet.html
- keep sed-safe escaping when substituting the description placeholder

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9cba5e0d483249cc13e55058b5031