### PR TITLE
Improve sed escaping for card snippet injection

### DIFF
--- a/.github/workflows/scheduled_posts.yml
+++ b/.github/workflows/scheduled_posts.yml
@@ -70,13 +70,13 @@ jobs:
 EOF
 
           # Inject dynamic values with sed-safe escaping
-          safe_title="$(printf '%s' "$title" | sed 's/[&#\/\\]/\\&/g')"
-          safe_description="$(printf '%s' "$description" | sed 's/[&#\/\\]/\\&/g')"
-          safe_filename="$(printf '%s' "$filename" | sed 's/[&#\/\\]/\\&/g')"
+          escape_for_sed() {
+            printf '%s' "$1" | sed 's/[&#\/\\]/\\&/g'
+          }
 
-          sed -i "s#TITLE_PLACEHOLDER#${safe_title}#" card_snippet.html
-          sed -i "s#DESCRIPTION_PLACEHOLDER#${safe_description}#" card_snippet.html
-          sed -i "s#FILENAME_PLACEHOLDER#${safe_filename}#" card_snippet.html
+          sed -i "s#TITLE_PLACEHOLDER#$(escape_for_sed "$title")#" card_snippet.html
+          sed -i "s#DESCRIPTION_PLACEHOLDER#$(escape_for_sed "$description")#" card_snippet.html
+          sed -i "s#FILENAME_PLACEHOLDER#$(escape_for_sed "$filename")#" card_snippet.html
 
       - name: Stop if no draft
         if: steps.pick.outputs.has_post != 'true'

--- a/.github/workflows/scheduled_posts.yml
+++ b/.github/workflows/scheduled_posts.yml
@@ -3,7 +3,7 @@ name: Scheduled posts
 on:
   schedule:
     - cron: '0 12 * * *'   # 12:00 UTC daily
-  workflow_dispatch:        # adds the "Run workflow" button
+  workflow_dispatch: {}     # adds the "Run workflow" button
 
 permissions:
   contents: write
@@ -69,14 +69,14 @@ jobs:
 </article>
 EOF
 
-          # Inject dynamic values
-          escape_for_sed() {
-            printf '%s' "$1" | sed 's/[&#\\]/\\&/g'
-          }
+          # Inject dynamic values with sed-safe escaping
+          safe_title="$(printf '%s' "$title" | sed 's/[&#\/\\]/\\&/g')"
+          safe_description="$(printf '%s' "$description" | sed 's/[&#\/\\]/\\&/g')"
+          safe_filename="$(printf '%s' "$filename" | sed 's/[&#\/\\]/\\&/g')"
 
-          sed -i "s#TITLE_PLACEHOLDER#$(escape_for_sed "$title")#" card_snippet.html
-          sed -i "s#DESCRIPTION_PLACEHOLDER#$(escape_for_sed "$description")#" card_snippet.html
-          sed -i "s#FILENAME_PLACEHOLDER#$(escape_for_sed "$filename")#" card_snippet.html
+          sed -i "s#TITLE_PLACEHOLDER#${safe_title}#" card_snippet.html
+          sed -i "s#DESCRIPTION_PLACEHOLDER#${safe_description}#" card_snippet.html
+          sed -i "s#FILENAME_PLACEHOLDER#${safe_filename}#" card_snippet.html
 
       - name: Stop if no draft
         if: steps.pick.outputs.has_post != 'true'

--- a/.github/workflows/scheduled_posts.yml
+++ b/.github/workflows/scheduled_posts.yml
@@ -3,7 +3,7 @@ name: Scheduled posts
 on:
   schedule:
     - cron: '0 12 * * *'   # 12:00 UTC daily
-  workflow_dispatch: {}     # adds the "Run workflow" button
+  workflow_dispatch:        # adds the "Run workflow" button
 
 permissions:
   contents: write
@@ -70,10 +70,13 @@ jobs:
 EOF
 
           # Inject dynamic values
-          sed -i "s#TITLE_PLACEHOLDER#$(printf '%s' "$title" | sed 's/[&/]/\\&/g')#" card_snippet.html
-          desc_html="$(printf '%s' "$description" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')"
-          sed -i "s#DESCRIPTION_PLACEHOLDER#$(printf '%s' "$desc_html" | sed 's/[&/]/\\&/g')#" card_snippet.html
-          sed -i "s#FILENAME_PLACEHOLDER#$(printf '%s' "$filename" | sed 's/[&/]/\\&/g')#" card_snippet.html
+          escape_for_sed() {
+            printf '%s' "$1" | sed 's/[&#\\]/\\&/g'
+          }
+
+          sed -i "s#TITLE_PLACEHOLDER#$(escape_for_sed "$title")#" card_snippet.html
+          sed -i "s#DESCRIPTION_PLACEHOLDER#$(escape_for_sed "$description")#" card_snippet.html
+          sed -i "s#FILENAME_PLACEHOLDER#$(escape_for_sed "$filename")#" card_snippet.html
 
       - name: Stop if no draft
         if: steps.pick.outputs.has_post != 'true'

--- a/.github/workflows/scheduled_posts.yml
+++ b/.github/workflows/scheduled_posts.yml
@@ -54,11 +54,26 @@ jobs:
           filename="$(basename "$post")"
           echo "filename=$filename" >> "$GITHUB_OUTPUT"
 
-          compact="$(tr -d '\n' < "$post")"
-          title="$(printf '%s' "$compact" | grep -oP '(?<=<title>).*?(?=</title>)' | head -n 1 || true)"
-          description="$(printf '%s' "$compact" | grep -oP '(?<=<meta\s+name=\"description\"\s+content=\").*?(?=\")' | head -n 1 || true)"
-          [ -n "$title" ] || title="${filename%.*}"
-          [ -n "$description" ] || description="New post: ${title}"
+          readarray -t meta < <(python3 - <<'PY' "$post")
+import sys, re, pathlib
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding='utf-8')
+compact = ''.join(text.splitlines())
+title_match = re.search(r'<title>(.*?)</title>', compact, flags=re.IGNORECASE)
+title = title_match.group(1).strip() if title_match else path.stem
+desc_match = re.search(r'<meta\s+name="description"\s+content="([^"]*)"', compact, flags=re.IGNORECASE)
+description = desc_match.group(1).strip() if desc_match else f"New post: {title}"
+print(title)
+print(description)
+PY
+          title="${meta[0]:-${filename%.*}}"
+          description="${meta[1]-}"
+          if [ -z "$title" ]; then
+            title="${filename%.*}"
+          fi
+          if [ -z "$description" ]; then
+            description="New post: ${title}"
+          fi
 
           # Build dark blog card snippet (no escaping)
           cat <<'EOF' > card_snippet.html

--- a/.github/workflows/scheduled_posts.yml
+++ b/.github/workflows/scheduled_posts.yml
@@ -54,8 +54,8 @@ jobs:
           filename="$(basename "$post")"
           echo "filename=$filename" >> "$GITHUB_OUTPUT"
 
-          readarray -t meta < <(python3 - <<'PY' "$post")
-import sys, re, pathlib
+          eval "$(python3 - "$post" <<'PY')"
+import sys, re, pathlib, shlex
 path = pathlib.Path(sys.argv[1])
 text = path.read_text(encoding='utf-8')
 compact = ''.join(text.splitlines())
@@ -63,15 +63,13 @@ title_match = re.search(r'<title>(.*?)</title>', compact, flags=re.IGNORECASE)
 title = title_match.group(1).strip() if title_match else path.stem
 desc_match = re.search(r'<meta\s+name="description"\s+content="([^"]*)"', compact, flags=re.IGNORECASE)
 description = desc_match.group(1).strip() if desc_match else f"New post: {title}"
-print(title)
-print(description)
+print(f"title={shlex.quote(title)}")
+print(f"description={shlex.quote(description)}")
 PY
-          title="${meta[0]:-${filename%.*}}"
-          description="${meta[1]-}"
-          if [ -z "$title" ]; then
+          if [ -z "${title:-}" ]; then
             title="${filename%.*}"
           fi
-          if [ -z "$description" ]; then
+          if [ -z "${description:-}" ]; then
             description="New post: ${title}"
           fi
 

--- a/.github/workflows/scheduled_posts.yml
+++ b/.github/workflows/scheduled_posts.yml
@@ -70,13 +70,13 @@ jobs:
 EOF
 
           # Inject dynamic values with sed-safe escaping
-          escape_for_sed() {
-            printf '%s' "$1" | sed 's/[&#\/\\]/\\&/g'
-          }
+          safe_title="$(printf '%s' "$title" | sed 's/[&#\/\\]/\\&/g')"
+          safe_description="$(printf '%s' "$description" | sed 's/[&#\/\\]/\\&/g')"
+          safe_filename="$(printf '%s' "$filename" | sed 's/[&#\/\\]/\\&/g')"
 
-          sed -i "s#TITLE_PLACEHOLDER#$(escape_for_sed "$title")#" card_snippet.html
-          sed -i "s#DESCRIPTION_PLACEHOLDER#$(escape_for_sed "$description")#" card_snippet.html
-          sed -i "s#FILENAME_PLACEHOLDER#$(escape_for_sed "$filename")#" card_snippet.html
+          sed -i "s#TITLE_PLACEHOLDER#${safe_title}#" card_snippet.html
+          sed -i "s#DESCRIPTION_PLACEHOLDER#${safe_description}#" card_snippet.html
+          sed -i "s#FILENAME_PLACEHOLDER#${safe_filename}#" card_snippet.html
 
       - name: Stop if no draft
         if: steps.pick.outputs.has_post != 'true'

--- a/index.html
+++ b/index.html
@@ -145,6 +145,7 @@
 
       <!-- BLOG:START -->
       <div class="grid md:grid-cols-3 gap-10">
+        <!--POST_PLACEHOLDER-->
         <article class="card shadow-lg overflow-hidden p-6 transition duration-300 transform hover:shadow-xl hover:-translate-y-1">
           <h3 class="text-xl font-semibold mb-3">Premonitions &amp; Intuition in Missing‑Person YA Thrillers</h3>
           <p class="mb-4">Explore how supernatural gifts and gut instincts drive YA mysteries about missing friends. Learn about premonition‑based thrillers and why diverse voices matter.</p>


### PR DESCRIPTION
## Summary
- add a helper to escape workflow substitutions safely
- ensure raw descriptions are inserted without HTML-entity conversion while still handling sed-sensitive characters

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d9cba5e0d483249cc13e55058b5031