### PR TITLE
Add dedicated blog index and align blog post styling

### DIFF
--- a/.github/workflows/scheduled_posts.yml
+++ b/.github/workflows/scheduled_posts.yml
@@ -54,11 +54,24 @@ jobs:
           filename="$(basename "$post")"
           echo "filename=$filename" >> "$GITHUB_OUTPUT"
 
-          compact="$(tr -d '\n' < "$post")"
-          title="$(printf '%s' "$compact" | grep -oP '(?<=<title>).*?(?=</title>)' | head -n 1 || true)"
-          description="$(printf '%s' "$compact" | grep -oP '(?<=<meta\s+name=\"description\"\s+content=\").*?(?=\")' | head -n 1 || true)"
-          [ -n "$title" ] || title="${filename%.*}"
-          [ -n "$description" ] || description="New post: ${title}"
+          eval "$(python3 - "$post" <<'PY')"
+import sys, re, pathlib, shlex
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding='utf-8')
+compact = ''.join(text.splitlines())
+title_match = re.search(r'<title>(.*?)</title>', compact, flags=re.IGNORECASE)
+title = title_match.group(1).strip() if title_match else path.stem
+desc_match = re.search(r'<meta\s+name="description"\s+content="([^"]*)"', compact, flags=re.IGNORECASE)
+description = desc_match.group(1).strip() if desc_match else f"New post: {title}"
+print(f"title={shlex.quote(title)}")
+print(f"description={shlex.quote(description)}")
+PY
+          if [ -z "${title:-}" ]; then
+            title="${filename%.*}"
+          fi
+          if [ -z "${description:-}" ]; then
+            description="New post: ${title}"
+          fi
 
           # Build dark blog card snippet (no escaping)
           cat <<'EOF' > card_snippet.html
@@ -69,11 +82,14 @@ jobs:
 </article>
 EOF
 
-          # Inject dynamic values
-          sed -i "s#TITLE_PLACEHOLDER#$(printf '%s' "$title" | sed 's/[&/]/\\&/g')#" card_snippet.html
-          desc_html="$(printf '%s' "$description" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')"
-          sed -i "s#DESCRIPTION_PLACEHOLDER#$(printf '%s' "$desc_html" | sed 's/[&/]/\\&/g')#" card_snippet.html
-          sed -i "s#FILENAME_PLACEHOLDER#$(printf '%s' "$filename" | sed 's/[&/]/\\&/g')#" card_snippet.html
+          # Inject dynamic values with sed-safe escaping
+          safe_title="$(printf '%s' "$title" | sed 's/[&#\/\\]/\\&/g')"
+          safe_description="$(printf '%s' "$description" | sed 's/[&#\/\\]/\\&/g')"
+          safe_filename="$(printf '%s' "$filename" | sed 's/[&#\/\\]/\\&/g')"
+
+          sed -i "s#TITLE_PLACEHOLDER#${safe_title}#" card_snippet.html
+          sed -i "s#DESCRIPTION_PLACEHOLDER#${safe_description}#" card_snippet.html
+          sed -i "s#FILENAME_PLACEHOLDER#${safe_filename}#" card_snippet.html
 
       - name: Stop if no draft
         if: steps.pick.outputs.has_post != 'true'

--- a/blog/10-signs-your-marriage-is-running-on-secrets.html
+++ b/blog/10-signs-your-marriage-is-running-on-secrets.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>10 Signs Your Marriage Is Running on Secrets</title>
+  <meta name="description" content="Ten blunt signs your marriage runs on secrecy—how to spot the drift, tell the truth, and rebuild trust before it snaps for good.">
+  <link rel="canonical" href="https://coreyljohnson.com/blog/10-signs-your-marriage-is-running-on-secrets">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --ink: #e5e7eb;
+      --navy: #1e3a8a;
+      --navy-700: #2743a0;
+      --page: #0f172a;
+      --subtle: #0b1220;
+    }
+
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: 'Inter', sans-serif;
+      background: var(--page);
+      color: #cbd5e1;
+    }
+
+    h1, h2, h3, h4 { color: var(--ink); }
+
+    .card {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      border-radius: 0.75rem;
+      color: #cbd5e1;
+    }
+
+    .link-accent { color: #93c5fd; }
+    .link-accent:hover { color: #bfdbfe; }
+  </style>
+</head>
+<body class="font-sans antialiased">
+  <header class="backdrop-blur-md sticky top-0 z-10" style="background: rgba(11,18,32,0.7); box-shadow: 0 1px 0 rgba(255,255,255,0.06);">
+    <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+      <a href="/index.html" class="text-2xl font-bold" style="color: var(--ink);">Corey L. Johnson</a>
+      <nav class="space-x-6 hidden md:block">
+        <a href="/index.html#books" class="hover:underline link-accent">Books</a>
+        <a href="/index.html#about" class="hover:underline link-accent">About</a>
+        <a href="/blog/index.html" class="hover:underline link-accent">Blog</a>
+        <a href="/index.html#contact" class="hover:underline link-accent">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container mx-auto px-4 py-12">
+    <article class="max-w-3xl mx-auto card p-8 md:p-10">
+      <h1 class="text-4xl font-bold mb-6">10 Signs Your Marriage Is Running on Secrets</h1>
+      <p class="mb-4">Secrecy rarely arrives as scandal. It shows up as silence, half-answers, and &ldquo;I&rsquo;m fine.&rdquo; Here are ten signs to address now&mdash;not later.</p>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">The Signs</h2>
+      <ol class="list-decimal pl-6 space-y-3">
+        <li><strong>Updates instead of honesty:</strong> You report the day, not what you feel.</li>
+        <li><strong>Money fog:</strong> Vague accounts, private purchases, defensive receipts.</li>
+        <li><strong>Calendar games:</strong> Edits and omissions around where you&rsquo;ll be.</li>
+        <li><strong>Two stories:</strong> The past shifts depending on who&rsquo;s listening.</li>
+        <li><strong>Phone anxiety:</strong> Face-down, never shared, &ldquo;don&rsquo;t touch that.&rdquo;</li>
+        <li><strong>Apologies with invoices:</strong> Every &ldquo;sorry&rdquo; demands a return favor.</li>
+        <li><strong>Topic traps:</strong> You avoid certain names, places, or dates.</li>
+        <li><strong>Logistics over intimacy:</strong> Roommates with rings.</li>
+        <li><strong>Private exit plan:</strong> &ldquo;Just in case&rdquo; becomes a habit.</li>
+        <li><strong>Waiting for proof:</strong> The pattern&rsquo;s clear&mdash;but you&rsquo;re hoping it isn&rsquo;t.</li>
+      </ol>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">What to Do Next</h2>
+      <ul class="list-disc pl-5 space-y-2 mb-6">
+        <li>Say <em>one</em> true thing you&rsquo;ve been avoiding. Out loud. Today.</li>
+        <li>Schedule a weekly check-in: 30 minutes, eye contact, no phones.</li>
+        <li>Bring a counselor in <em>before</em> the emergency.</li>
+      </ul>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">Want stories that tell the truth about marriage?</h2>
+      <p class="mb-2">Read my Southern family drama about secrets and second chances:</p>
+      <p class="mb-2">👉 <a href="https://a.co/d/bIOYPL0" target="_blank" rel="noopener" class="link-accent underline">The Grass Is Always Greener &mdash; Amazon</a></p>
+      <p class="mb-2">For a small-town YA thriller about loyalty and justice:</p>
+      <p class="mb-0">👉 <a href="https://a.co/d/cUCeKhh" target="_blank" rel="noopener" class="link-accent underline">They Never Came Home &mdash; Amazon</a></p>
+      <p class="mt-4">Explore more on the <a href="/index.html#books" class="link-accent underline">Books page</a>.</p>
+    </article>
+  </main>
+
+  <footer class="py-8" style="background: rgba(11,18,32,0.9);">
+    <div class="container mx-auto px-4 text-center text-slate-300">
+      <p>&copy; <span id="year"></span> Corey L. Johnson. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/blog/21-brutal-questions-before-i-do.html
+++ b/blog/21-brutal-questions-before-i-do.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>21 Brutal Questions to Ask Before You Say “I Do”</title>
+  <meta name="description" content="Twenty-one tough questions about money, loyalty, faith, family, and conflict—asked now, so you don’t pay for silence later. Print and be honest.">
+  <link rel="canonical" href="https://coreyljohnson.com/blog/21-brutal-questions-before-i-do">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --ink: #e5e7eb;
+      --navy: #1e3a8a;
+      --navy-700: #2743a0;
+      --page: #0f172a;
+      --subtle: #0b1220;
+    }
+
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: 'Inter', sans-serif;
+      background: var(--page);
+      color: #cbd5e1;
+    }
+
+    h1, h2, h3, h4 { color: var(--ink); }
+
+    .card {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      border-radius: 0.75rem;
+      color: #cbd5e1;
+    }
+
+    .link-accent { color: #93c5fd; }
+    .link-accent:hover { color: #bfdbfe; }
+  </style>
+</head>
+<body class="font-sans antialiased">
+  <header class="backdrop-blur-md sticky top-0 z-10" style="background: rgba(11,18,32,0.7); box-shadow: 0 1px 0 rgba(255,255,255,0.06);">
+    <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+      <a href="/index.html" class="text-2xl font-bold" style="color: var(--ink);">Corey L. Johnson</a>
+      <nav class="space-x-6 hidden md:block">
+        <a href="/index.html#books" class="hover:underline link-accent">Books</a>
+        <a href="/index.html#about" class="hover:underline link-accent">About</a>
+        <a href="/blog/index.html" class="hover:underline link-accent">Blog</a>
+        <a href="/index.html#contact" class="hover:underline link-accent">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container mx-auto px-4 py-12">
+    <article class="max-w-3xl mx-auto card p-8 md:p-10">
+      <h1 class="text-4xl font-bold mb-6">21 Brutal Questions to Ask Before You Say &ldquo;I Do&rdquo;</h1>
+      <p class="mb-4">Love is a promise. Marriage is a plan. These questions won&rsquo;t ruin romance&mdash;they protect it.</p>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">The Questions</h2>
+      <ol class="list-decimal pl-6 space-y-3">
+        <li>How do we fight&mdash;and how do we end a fight?</li>
+        <li>What counts as &ldquo;cheating&rdquo; to you?</li>
+        <li>Who handles money? What&rsquo;s our monthly plan?</li>
+        <li>Kids: when, how many, and what if it&rsquo;s hard?</li>
+        <li>What does faith look like in our week?</li>
+        <li>Where&rsquo;s the line between privacy and secrecy?</li>
+        <li>Whose family has the loudest vote in our house?</li>
+        <li>What&rsquo;s our boundary with work after 7 p.m.?</li>
+        <li>How do we support mental health&mdash;yours and mine?</li>
+        <li>What holidays matter, and where do we spend them?</li>
+        <li>What do we owe our pasts&mdash;and to whom?</li>
+        <li>What&rsquo;s our rule about exes and &ldquo;old friends&rdquo;?</li>
+        <li>What does intimacy mean when life gets busy?</li>
+        <li>How do we handle debt, savings, and giving?</li>
+        <li>What&rsquo;s non-negotiable for your health and mine?</li>
+        <li>How do we apologize&mdash;and what makes it real?</li>
+        <li>Who do we become under stress?</li>
+        <li>What&rsquo;s one dream you won&rsquo;t sacrifice?</li>
+        <li>What are we building in five years?</li>
+        <li>What fear are you afraid to tell me?</li>
+        <li>What promise can I actually hold you to?</li>
+      </ol>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">Want fiction that takes these questions seriously?</h2>
+      <p class="mb-2">👉 <a href="https://a.co/d/bIOYPL0" target="_blank" rel="noopener" class="link-accent underline"><em>The Grass Is Always Greener</em> &mdash; Amazon</a></p>
+      <p class="mb-2">👉 <a href="https://a.co/d/cUCeKhh" target="_blank" rel="noopener" class="link-accent underline"><em>They Never Came Home</em> &mdash; Amazon</a></p>
+      <p class="mt-4">See all titles on the <a href="/index.html#books" class="link-accent underline">Books page</a>.</p>
+    </article>
+  </main>
+
+  <footer class="py-8" style="background: rgba(11,18,32,0.9);">
+    <div class="container mx-auto px-4 text-center text-slate-300">
+      <p>&copy; <span id="year"></span> Corey L. Johnson. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/blog/african-american-ya-thrillers.html
+++ b/blog/african-american-ya-thrillers.html
@@ -10,30 +10,51 @@
   <!-- Google Font -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <style>
+    :root {
+      --ink: #e5e7eb;
+      --navy: #1e3a8a;
+      --navy-700: #2743a0;
+      --page: #0f172a;
+      --subtle: #0b1220;
+    }
+
+    html { scroll-behavior: smooth; }
     body {
       font-family: 'Inter', sans-serif;
+      background: var(--page);
+      color: #cbd5e1;
     }
-    html {
-      scroll-behavior: smooth;
+
+    h1, h2, h3, h4 { color: var(--ink); }
+
+    .card {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      border-radius: 0.75rem;
+      color: #cbd5e1;
     }
+
+    .link-accent { color: #93c5fd; }
+    .link-accent:hover { color: #bfdbfe; }
   </style>
 </head>
-<body class="bg-gray-50 text-gray-800">
+<body class="font-sans antialiased">
   <!-- Navigation -->
-  <header class="bg-white/80 backdrop-blur-md shadow-md sticky top-0 z-10">
+  <header class="backdrop-blur-md sticky top-0 z-10" style="background: rgba(11,18,32,0.7); box-shadow: 0 1px 0 rgba(255,255,255,0.06);">
     <div class="container mx-auto px-4 py-4 flex justify-between items-center">
-      <a href="/index.html" class="text-2xl font-bold text-gray-800">Corey L. Johnson</a>
+      <a href="/index.html" class="text-2xl font-bold" style="color: var(--ink);">Corey L. Johnson</a>
       <nav class="space-x-6 hidden md:block">
-        <a href="/index.html#books" class="text-gray-700 hover:text-gray-900 transition-colors">Books</a>
-        <a href="/index.html#about" class="text-gray-700 hover:text-gray-900 transition-colors">About</a>
-        <a href="/index.html#blog" class="text-gray-700 hover:text-gray-900 transition-colors">Blog</a>
-        <a href="/index.html#contact" class="text-gray-700 hover:text-gray-900 transition-colors">Contact</a>
+        <a href="/index.html#books" class="hover:underline link-accent">Books</a>
+        <a href="/index.html#about" class="hover:underline link-accent">About</a>
+        <a href="/blog/index.html" class="hover:underline link-accent">Blog</a>
+        <a href="/index.html#contact" class="hover:underline link-accent">Contact</a>
       </nav>
     </div>
   </header>
 
   <main class="container mx-auto px-4 py-12">
-    <article class="max-w-3xl mx-auto">
+    <article class="max-w-3xl mx-auto card p-8 md:p-10">
       <h1 class="text-4xl font-bold mb-6">African‑American YA Thrillers About Missing Girls</h1>
       <p class="mb-4">Young adult readers love nothing more than a story that pulls them to the edge of their seat. When the plot centers on a disappearance, the pages almost turn themselves. But for many years those missing from the story page were Black characters themselves. In 1965, children’s literature critic Nancy&nbsp;Larrick analyzed more than 5,000 books published between 1962 and 1964 and found only <strong>40</strong> that contained contemporary African‑American characters. That “all‑white world” sparked outrage and helped spur the creation of awards and organizations to amplify Black voices. Despite progress since then, Black protagonists remain rare in YA thriller shelves—and rarer still in mysteries centered on missing girls.</p>
       <p class="mb-4">This post shines a light on that gap while celebrating authors who are changing it. We’ll explore why representation in thrillers matters, recommend standout books with Black leads, and introduce Corey&nbsp;L.&nbsp;Johnson’s latest YA thriller <em>They&nbsp;Never&nbsp;Came&nbsp;Home</em>, a gripping mystery that demands your attention.</p>
@@ -44,8 +65,8 @@
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">Spotlight: <em>They&nbsp;Never&nbsp;Came&nbsp;Home</em> by Corey&nbsp;L.&nbsp;Johnson</h2>
       <p class="mb-4">Three girls vanish from a small Tennessee town. Parents whisper, journalists descend and everyone asks the same question: <strong>Where are they?</strong> In this tense YA thriller, Corey&nbsp;L.&nbsp;Johnson introduces us to <strong>Jaylen</strong>, a Black teen whose cousin is among the missing. As rumors swirl and fear spreads, Jaylen undertakes his own investigation when he realizes that law enforcement isn’t looking hard enough. The search uncovers buried secrets about the town—and about Jaylen’s family—that will keep you guessing until the last page.</p>
-      <blockquote class="mb-4 italic border-l-4 border-blue-600 pl-4">“They Never Came Home is a gripping exploration of how communities respond when Black girls go missing—and who is left to do the searching.”</blockquote>
-      <p class="mb-4"><em>They&nbsp;Never&nbsp;Came&nbsp;Home</em> blends fast‑paced mystery with an unflinching look at race, media bias, and the bonds of family. It’s perfect for teens and adults who enjoy thrillers that do more than entertain; they challenge readers to think. <a href="https://a.co/d/cVwd3TI" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline hover:text-blue-800">Read it on Amazon</a> and see why this YA thriller deserves a place on your shelf.</p>
+      <blockquote class="mb-4 italic border-l-4 border-indigo-400/80 pl-4">“They Never Came Home is a gripping exploration of how communities respond when Black girls go missing—and who is left to do the searching.”</blockquote>
+      <p class="mb-4"><em>They&nbsp;Never&nbsp;Came&nbsp;Home</em> blends fast‑paced mystery with an unflinching look at race, media bias, and the bonds of family. It’s perfect for teens and adults who enjoy thrillers that do more than entertain; they challenge readers to think. <a href="https://a.co/d/cVwd3TI" target="_blank" rel="noopener noreferrer" class="link-accent underline hover:underline">Read it on Amazon</a> and see why this YA thriller deserves a place on your shelf.</p>
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">8 other YA thrillers featuring Black protagonists</h2>
 
@@ -105,9 +126,9 @@
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">Subtle calls to action</h2>
       <ul class="list-disc pl-5 mb-4">
-        <li class="mb-2"><strong>Discover the mystery:</strong> If you’re ready for a suspenseful journey through family secrets and small‑town whispers, <a href="https://a.co/d/cVwd3TI" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline hover:text-blue-800">read <em>They Never Came Home</em> on Amazon</a>.</li>
-        <li class="mb-2"><strong>Join the mailing list:</strong> Want behind‑the‑scenes insights and exclusive previews? <a href="/index.html#contact" class="text-blue-600 underline hover:text-blue-800">Sign up for Corey L. Johnson’s newsletter</a> and never miss a new release.</li>
-        <li class="mb-2"><strong>Explore more stories:</strong> For heart‑wrenching tales of marriage and healing, check out Corey’s contemporary novel <em>The Grass Is Always Greener</em> <a href="https://a.co/d/93FOaLR" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline hover:text-blue-800">here</a>.</li>
+        <li class="mb-2"><strong>Discover the mystery:</strong> If you’re ready for a suspenseful journey through family secrets and small‑town whispers, <a href="https://a.co/d/cVwd3TI" target="_blank" rel="noopener noreferrer" class="link-accent underline hover:underline">read <em>They Never Came Home</em> on Amazon</a>.</li>
+        <li class="mb-2"><strong>Join the mailing list:</strong> Want behind‑the‑scenes insights and exclusive previews? <a href="/index.html#contact" class="link-accent underline hover:underline">Sign up for Corey L. Johnson’s newsletter</a> and never miss a new release.</li>
+        <li class="mb-2"><strong>Explore more stories:</strong> For heart‑wrenching tales of marriage and healing, check out Corey’s contemporary novel <em>The Grass Is Always Greener</em> <a href="https://a.co/d/93FOaLR" target="_blank" rel="noopener noreferrer" class="link-accent underline hover:underline">here</a>.</li>
       </ul>
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">Image suggestions</h2>
@@ -117,15 +138,15 @@
       <p class="mb-4">4. <strong>Map or neighborhood street</strong> representing the small‑town setting of <em>They Never Came Home</em>. <em>Alt text:</em> “Quiet neighborhood street at dusk with streetlights glowing.”</p>
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">What to read next</h2>
-      <p class="mb-4">If you enjoyed this deep dive into YA thrillers and crave more contemplative fiction, visit our <a href="/index.html#books" class="text-blue-600 underline hover:text-blue-800">Books</a> page for other stories by Corey L. Johnson. You’ll find novels that blend faith, family and the choices we make. Start with <em>The Grass Is Always Greener</em>—a moving exploration of love and second chances.</p>
+      <p class="mb-4">If you enjoyed this deep dive into YA thrillers and crave more contemplative fiction, visit our <a href="/index.html#books" class="link-accent underline hover:underline">Books</a> page for other stories by Corey L. Johnson. You’ll find novels that blend faith, family and the choices we make. Start with <em>The Grass Is Always Greener</em>—a moving exploration of love and second chances.</p>
 
-      <p class="text-sm text-gray-500">Note: This article is for informational and promotional purposes. Some links may be affiliate links.</p>
+      <p class="text-sm text-slate-400">Note: This article is for informational and promotional purposes. Some links may be affiliate links.</p>
     </article>
   </main>
 
   <!-- Footer -->
-  <footer class="bg-gray-900 text-gray-200 py-8">
-    <div class="container mx-auto px-4 text-center">
+  <footer class="py-8" style="background: rgba(11,18,32,0.9);">
+    <div class="container mx-auto px-4 text-center text-slate-300">
       <p>&copy; <span id="year"></span> Corey L. Johnson. All rights reserved.</p>
     </div>
   </footer>

--- a/blog/character-deep-dive-malik-thompson.html
+++ b/blog/character-deep-dive-malik-thompson.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Character Deep Dive: Malik Thompson</title>
+  <meta name="description" content="Meet Malik Thompson, the sharp and loyal teen at the heart of They Never Came Home, a YA thriller about missing girls and community secrets.">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --ink: #e5e7eb;
+      --navy: #1e3a8a;
+      --navy-700: #2743a0;
+      --page: #0f172a;
+      --subtle: #0b1220;
+    }
+
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: 'Inter', sans-serif;
+      background: var(--page);
+      color: #cbd5e1;
+    }
+
+    h1, h2, h3, h4 { color: var(--ink); }
+
+    .card {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      border-radius: 0.75rem;
+      color: #cbd5e1;
+    }
+
+    .link-accent { color: #93c5fd; }
+    .link-accent:hover { color: #bfdbfe; }
+
+    .btn-primary {
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      border-radius: 9999px;
+      font-weight: 600;
+      padding: 0.875rem 1.75rem;
+      background: var(--navy);
+      color: #fff;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      box-shadow: 0 10px 25px rgba(30, 58, 138, 0.35);
+    }
+
+    .btn-primary:hover {
+      background: var(--navy-700);
+      transform: translateY(-2px);
+      box-shadow: 0 12px 30px rgba(30, 58, 138, 0.45);
+    }
+  </style>
+</head>
+<body class="font-sans antialiased">
+  <header class="backdrop-blur-md sticky top-0 z-10" style="background: rgba(11,18,32,0.7); box-shadow: 0 1px 0 rgba(255,255,255,0.06);">
+    <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+      <a href="/index.html" class="text-2xl font-bold" style="color: var(--ink);">Corey L. Johnson</a>
+      <nav class="space-x-6 hidden md:block">
+        <a href="/index.html#books" class="hover:underline link-accent">Books</a>
+        <a href="/index.html#about" class="hover:underline link-accent">About</a>
+        <a href="/blog/index.html" class="hover:underline link-accent">Blog</a>
+        <a href="/index.html#contact" class="hover:underline link-accent">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container mx-auto px-4 py-12">
+    <article class="max-w-3xl mx-auto card p-8 md:p-10">
+      <h1 class="text-4xl font-bold mb-6">Character Deep Dive: Malik Thompson</h1>
+      <p class="mb-4 text-lg">At the center of <em>They Never Came Home</em> stands <strong>Malik Thompson</strong>&mdash;a character whose mix of sharp intellect, loyalty, and restless curiosity makes him one of the most compelling YA thriller protagonists in recent memory. Readers quickly learn that Malik isn&rsquo;t just another teen caught up in small-town drama&mdash;he&rsquo;s the kind of hero who can&rsquo;t look away when the truth is buried.</p>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">Who Is Malik?</h2>
+      <p class="mb-4">Raised in Queens, Malik brings big-city instincts to the rural South. He&rsquo;s street-smart, suspicious of authority, and fiercely protective of the people he loves. His ability to read situations and trust his gut often sets him apart&mdash;and sometimes puts him in danger.</p>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">Why Readers Connect with Him</h2>
+      <ul class="list-disc pl-5 mb-4 space-y-2">
+        <li><strong>Curiosity that won&rsquo;t quit:</strong> Malik can&rsquo;t stop asking questions, even when the adults in his life want him silent.</li>
+        <li><strong>Protective loyalty:</strong> Once someone earns his trust, he&rsquo;ll do whatever it takes to stand by them.</li>
+        <li><strong>Emotional depth:</strong> Beneath his confidence, Malik wrestles with belonging, responsibility, and fear of loss.</li>
+      </ul>
+      <p class="mb-4">This mix of toughness and vulnerability makes him both relatable and admirable. Readers see not just a mystery-solver, but a teen navigating loyalty, justice, and the weight of growing up too fast.</p>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">Malik&rsquo;s Role in the Story</h2>
+      <p class="mb-4">In <em>They Never Came Home</em>, Malik becomes more than an observer&mdash;he&rsquo;s the driving force behind uncovering truths others ignore. His determination transforms him from outsider to unexpected protector, proving that courage isn&rsquo;t about fearlessness, but about refusing to look away when others do.</p>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">Why He Stands Out in YA Thrillers</h2>
+      <p class="mb-4">Too often, thrillers sideline Black teens or reduce them to stereotypes. Malik breaks that mold. He&rsquo;s layered, complex, and written with authenticity&mdash;a Black protagonist who feels real, with all the contradictions and strengths that make young people unforgettable.</p>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">Takeaway</h2>
+      <p class="mb-8">Malik Thompson isn&rsquo;t just a character; he&rsquo;s a reminder of what it means to fight for truth and belonging in a world that would rather stay comfortable in silence. Readers who meet him on the page won&rsquo;t forget him.</p>
+
+      <div class="grid md:grid-cols-2 gap-4">
+        <a href="https://a.co/d/cUCeKhh" target="_blank" rel="noopener noreferrer" class="btn-primary">Read <em>They Never Came Home</em> on Amazon</a>
+        <a href="https://a.co/d/bIOYPL0" target="_blank" rel="noopener noreferrer" class="btn-primary" style="background:#16a34a; box-shadow:0 10px 25px rgba(22,163,74,0.3);">Read <em>The Grass Is Always Greener</em> on Amazon</a>
+      </div>
+    </article>
+  </main>
+
+  <footer class="py-8" style="background: rgba(11,18,32,0.9);">
+    <div class="container mx-auto px-4 text-center text-slate-300">
+      <p>&copy; <span id="year"></span> Corey L. Johnson. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/blog/family-secrets-in-fiction.html
+++ b/blog/family-secrets-in-fiction.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Family Secrets in Fiction: Why We Can’t Look Away</title>
+  <meta name="description" content="Why family secrets power unforgettable fiction—betrayal, loyalty, forgiveness, and the relief and cost of truth when it finally arrives.">
+  <link rel="canonical" href="https://coreyljohnson.com/blog/family-secrets-in-fiction">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --ink: #e5e7eb;
+      --navy: #1e3a8a;
+      --navy-700: #2743a0;
+      --page: #0f172a;
+      --subtle: #0b1220;
+    }
+
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: 'Inter', sans-serif;
+      background: var(--page);
+      color: #cbd5e1;
+    }
+
+    h1, h2, h3, h4 { color: var(--ink); }
+
+    .card {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      border-radius: 0.75rem;
+      color: #cbd5e1;
+    }
+
+    .link-accent { color: #93c5fd; }
+    .link-accent:hover { color: #bfdbfe; }
+  </style>
+</head>
+<body class="font-sans antialiased">
+  <header class="backdrop-blur-md sticky top-0 z-10" style="background: rgba(11,18,32,0.7); box-shadow: 0 1px 0 rgba(255,255,255,0.06);">
+    <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+      <a href="/index.html" class="text-2xl font-bold" style="color: var(--ink);">Corey L. Johnson</a>
+      <nav class="space-x-6 hidden md:block">
+        <a href="/index.html#books" class="hover:underline link-accent">Books</a>
+        <a href="/index.html#about" class="hover:underline link-accent">About</a>
+        <a href="/blog/index.html" class="hover:underline link-accent">Blog</a>
+        <a href="/index.html#contact" class="hover:underline link-accent">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container mx-auto px-4 py-12">
+    <article class="max-w-3xl mx-auto card p-8 md:p-10">
+      <h1 class="text-4xl font-bold mb-6">Family Secrets in Fiction: Why We Can&rsquo;t Look Away</h1>
+      <p class="mb-4">One buried truth can reorder a house. That&rsquo;s why stories built on secrets pull us in&mdash;they ask what love looks like when honesty is expensive.</p>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">How Secrets Drive a Story</h2>
+      <ul class="list-disc pl-5 space-y-2 mb-6">
+        <li><strong>Hidden motives:</strong> Everyone thinks they&rsquo;re protecting someone.</li>
+        <li><strong>Clock pressure:</strong> The longer it lives, the more it costs.</li>
+        <li><strong>Reckoning:</strong> Truth heals some things and breaks others.</li>
+      </ul>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">Want a Southern story about truth and grace?</h2>
+      <p class="mb-2">👉 <a href="https://a.co/d/bIOYPL0" target="_blank" rel="noopener" class="link-accent underline"><em>The Grass Is Always Greener</em> &mdash; Amazon</a></p>
+      <p class="mb-2">Prefer small-town suspense with community stakes?</p>
+      <p class="mb-0">👉 <a href="https://a.co/d/cUCeKhh" target="_blank" rel="noopener" class="link-accent underline"><em>They Never Came Home</em> &mdash; Amazon</a></p>
+      <p class="mt-4">More titles on the <a href="/index.html#books" class="link-accent underline">Books page</a>.</p>
+    </article>
+  </main>
+
+  <footer class="py-8" style="background: rgba(11,18,32,0.9);">
+    <div class="container mx-auto px-4 text-center text-slate-300">
+      <p>&copy; <span id="year"></span> Corey L. Johnson. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/blog/how-to-write-suspense-without-gore-11-05-09-am.html
+++ b/blog/how-to-write-suspense-without-gore-11-05-09-am.html
@@ -10,30 +10,51 @@
   <!-- Google Font -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <style>
+    :root {
+      --ink: #e5e7eb;
+      --navy: #1e3a8a;
+      --navy-700: #2743a0;
+      --page: #0f172a;
+      --subtle: #0b1220;
+    }
+
+    html { scroll-behavior: smooth; }
     body {
       font-family: 'Inter', sans-serif;
+      background: var(--page);
+      color: #cbd5e1;
     }
-    html {
-      scroll-behavior: smooth;
+
+    h1, h2, h3, h4 { color: var(--ink); }
+
+    .card {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      border-radius: 0.75rem;
+      color: #cbd5e1;
     }
+
+    .link-accent { color: #93c5fd; }
+    .link-accent:hover { color: #bfdbfe; }
   </style>
 </head>
-<body class="bg-gray-50 text-gray-800">
+<body class="font-sans antialiased">
   <!-- Navigation -->
-  <header class="bg-white/80 backdrop-blur-md shadow-md sticky top-0 z-10">
+  <header class="backdrop-blur-md sticky top-0 z-10" style="background: rgba(11,18,32,0.7); box-shadow: 0 1px 0 rgba(255,255,255,0.06);">
     <div class="container mx-auto px-4 py-4 flex justify-between items-center">
-      <a href="/index.html" class="text-2xl font-bold text-gray-800">Corey L. Johnson</a>
+      <a href="/index.html" class="text-2xl font-bold" style="color: var(--ink);">Corey L. Johnson</a>
       <nav class="space-x-6 hidden md:block">
-        <a href="/index.html#books" class="text-gray-700 hover:text-gray-900 transition-colors">Books</a>
-        <a href="/index.html#about" class="text-gray-700 hover:text-gray-900 transition-colors">About</a>
-        <a href="/index.html#blog" class="text-gray-700 hover:text-gray-900 transition-colors">Blog</a>
-        <a href="/index.html#contact" class="text-gray-700 hover:text-gray-900 transition-colors">Contact</a>
+        <a href="/index.html#books" class="hover:underline link-accent">Books</a>
+        <a href="/index.html#about" class="hover:underline link-accent">About</a>
+        <a href="/blog/index.html" class="hover:underline link-accent">Blog</a>
+        <a href="/index.html#contact" class="hover:underline link-accent">Contact</a>
       </nav>
     </div>
   </header>
 
   <main class="container mx-auto px-4 py-12">
-    <article class="max-w-3xl mx-auto">
+    <article class="max-w-3xl mx-auto card p-8 md:p-10">
       <h1 class="text-4xl font-bold mb-6">Writing Suspense Without Gore: Building Tension Through Atmosphere</h1>
       <p class="mb-4">When people think of thrillers, they often imagine grisly scenes and jump scares. But true suspense isn’t about splatter; it’s about uncertainty. It’s the tightening feeling in your chest when a character turns down a dark hallway, the dread that builds as secrets unravel. For readers who crave tension without graphic violence, authors must lean on atmosphere, pacing and psychological stakes. Corey L. Johnson’s novels show how gripping stories can be without gore: <em>They Never Came Home</em> focuses on missing girls and community secrets, and <em>The Grass Is Always Greener</em> explores family drama and moral choices. Both keep readers riveted through mood and character development rather than shock value.</p>
 
@@ -80,9 +101,9 @@
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">Calls to action</h2>
       <ul class="list-disc pl-5 mb-4">
-        <li class="mb-2">Experience tension without gore by reading <a href="https://a.co/d/cVwd3TI" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline hover:text-blue-800"><em>They Never Came Home</em></a>, a YA thriller that keeps you guessing.</li>
-        <li class="mb-2">Dive into a tale of family secrets and redemption with <a href="https://a.co/d/93FOaLR" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline hover:text-blue-800"><em>The Grass Is Always Greener</em></a>.</li>
-        <li class="mb-2">Get writing tips, character insights and exclusive previews when you join Corey L. Johnson’s <a href="/index.html#contact" class="text-blue-600 underline hover:text-blue-800">newsletter</a>.</li>
+        <li class="mb-2">Experience tension without gore by reading <a href="https://a.co/d/cVwd3TI" target="_blank" rel="noopener noreferrer" class="link-accent underline hover:underline"><em>They Never Came Home</em></a>, a YA thriller that keeps you guessing.</li>
+        <li class="mb-2">Dive into a tale of family secrets and redemption with <a href="https://a.co/d/93FOaLR" target="_blank" rel="noopener noreferrer" class="link-accent underline hover:underline"><em>The Grass Is Always Greener</em></a>.</li>
+        <li class="mb-2">Get writing tips, character insights and exclusive previews when you join Corey L. Johnson’s <a href="/index.html#contact" class="link-accent underline hover:underline">newsletter</a>.</li>
       </ul>
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">Image suggestions</h2>
@@ -92,15 +113,15 @@
       <p class="mb-4">4. <strong>Softly lit farmhouse at dusk</strong>. <em>Alt text:</em> “Old farmhouse bathed in golden evening light.”</p>
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">What to read next</h2>
-      <p class="mb-4">If you’re inspired to write your own low‑gore thriller or simply want more atmospheric reads, explore our <a href="/index.html#books" class="text-blue-600 underline hover:text-blue-800">Books</a> section. You’ll find titles that prove suspense comes in many forms.</p>
+      <p class="mb-4">If you’re inspired to write your own low‑gore thriller or simply want more atmospheric reads, explore our <a href="/index.html#books" class="link-accent underline hover:underline">Books</a> section. You’ll find titles that prove suspense comes in many forms.</p>
 
-      <p class="text-sm text-gray-500">Note: This article is for informational and promotional purposes. Some links may be affiliate links.</p>
+      <p class="text-sm text-slate-400">Note: This article is for informational and promotional purposes. Some links may be affiliate links.</p>
     </article>
   </main>
 
   <!-- Footer -->
-  <footer class="bg-gray-900 text-gray-200 py-8">
-    <div class="container mx-auto px-4 text-center">
+  <footer class="py-8" style="background: rgba(11,18,32,0.9);">
+    <div class="container mx-auto px-4 text-center text-slate-300">
       <p>&copy; <span id="year"></span> Corey L. Johnson. All rights reserved.</p>
     </div>
   </footer>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Blog – Corey L. Johnson</title>
+  <meta name="description" content="Read the latest updates from Corey L. Johnson, including news, essays, and resources about young adult thrillers." />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --ink: #e5e7eb;
+      --navy: #1e3a8a;
+      --navy-700: #2743a0;
+      --page: #0f172a;
+      --subtle: #0b1220;
+    }
+
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: 'Inter', sans-serif;
+      background: var(--page);
+      color: #cbd5e1;
+    }
+
+    h1, h2, h3, h4 {
+      color: var(--ink);
+    }
+
+    .btn-primary {
+      background: var(--navy);
+      color: #fff;
+    }
+    .btn-primary:hover {
+      background: var(--navy-700);
+    }
+
+    .card {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      border-radius: 0.75rem;
+      color: #cbd5e1;
+    }
+
+    .link-accent { color: #93c5fd; }
+    .link-accent:hover { color: #bfdbfe; }
+  </style>
+</head>
+<body class="font-sans antialiased">
+  <header class="backdrop-blur-md sticky top-0 z-10" style="background: rgba(11,18,32,0.7); box-shadow: 0 1px 0 rgba(255,255,255,0.06);">
+    <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+      <a href="/index.html" class="text-2xl font-bold" style="color: var(--ink);">Corey L. Johnson</a>
+      <nav class="space-x-6 hidden md:block">
+        <a href="/index.html#books" class="hover:underline link-accent">Books</a>
+        <a href="/index.html#about" class="hover:underline link-accent">About</a>
+        <a href="/blog/index.html" class="hover:underline link-accent">Blog</a>
+        <a href="/index.html#contact" class="hover:underline link-accent">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container mx-auto px-4 py-16">
+    <section class="max-w-4xl mx-auto mb-12 text-center">
+      <h1 class="text-4xl md:text-5xl font-extrabold mb-4">Blog</h1>
+      <p class="text-lg md:text-xl text-slate-300">Browse articles, resources, and behind-the-scenes updates about Corey L. Johnson&#39;s young adult thrillers.</p>
+    </section>
+
+    <section class="max-w-4xl mx-auto">
+      <div id="post-list" class="space-y-6" aria-live="polite">
+        <p class="text-center text-slate-400">Loading posts…</p>
+      </div>
+      <noscript>
+        <ul class="list-disc pl-5 mt-6 space-y-2 text-left text-slate-300">
+          <li><a href="/blog/premonitions-intuition-solving-disappearances.html" class="link-accent underline">Premonitions &amp; Intuition in Missing‑Person YA Thrillers</a></li>
+          <li><a href="/blog/real-life-cases-missing-girls-of-color.html" class="link-accent underline">Real-Life Cases of Missing Girls of Color</a></li>
+          <li><a href="/blog/african-american-ya-thrillers.html" class="link-accent underline">Top African‑American YA Thrillers: Missing Girls &amp; Mystery</a></li>
+          <li><a href="/blog/why-representation-matters-ya-thrillers.html" class="link-accent underline">Why Representation Matters in YA Thrillers</a></li>
+          <li><a href="/blog/how-to-write-suspense-without-gore-11-05-09-am.html" class="link-accent underline">Writing Suspense Without Gore: Building Tension Through Atmosphere</a></li>
+        </ul>
+      </noscript>
+    </section>
+  </main>
+
+  <footer class="py-8" style="background: rgba(11,18,32,0.9);">
+    <div class="container mx-auto px-4 text-center text-slate-300">
+      <p>&copy; <span id="year"></span> Corey L. Johnson. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+
+    async function loadPosts() {
+      const container = document.getElementById('post-list');
+      if (!container) return;
+
+      try {
+        const response = await fetch('/blog/posts.json', { cache: 'no-store' });
+        if (!response.ok) throw new Error('Unable to fetch posts');
+        const posts = await response.json();
+
+        if (!Array.isArray(posts) || posts.length === 0) {
+          container.innerHTML = '<p class="text-center text-slate-400">No published posts yet—check back soon.</p>';
+          return;
+        }
+
+        container.innerHTML = '';
+        const fragment = document.createDocumentFragment();
+
+        posts.forEach((post) => {
+          const article = document.createElement('article');
+          article.className = 'card p-6 transition duration-300 transform hover:shadow-xl hover:-translate-y-1';
+
+          const title = document.createElement('h2');
+          title.className = 'text-2xl font-semibold mb-2';
+
+          const link = document.createElement('a');
+          const href = typeof post.href === 'string' ? post.href : '';
+          link.href = href.startsWith('/') ? href : '/' + href.replace(/^\//, '');
+          link.className = 'link-accent hover:underline';
+          link.textContent = post.title || 'Untitled post';
+          title.appendChild(link);
+
+          const excerpt = document.createElement('p');
+          excerpt.className = 'text-slate-300';
+          excerpt.textContent = post.excerpt || '';
+
+          article.appendChild(title);
+          article.appendChild(excerpt);
+          fragment.appendChild(article);
+        });
+
+        container.appendChild(fragment);
+      } catch (error) {
+        console.error('Failed to load blog posts', error);
+        container.innerHTML = '<p class="text-center text-slate-400">Unable to load posts right now. Please refresh the page.</p>';
+      }
+    }
+
+    loadPosts();
+  </script>
+</body>
+</html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -72,6 +72,13 @@
       </div>
       <noscript>
         <ul class="list-disc pl-5 mt-6 space-y-2 text-left text-slate-300">
+          <li><a href="/blog/character-deep-dive-malik-thompson.html" class="link-accent underline">Character Deep Dive: Malik Thompson</a></li>
+          <li><a href="/blog/10-signs-your-marriage-is-running-on-secrets.html" class="link-accent underline">10 Signs Your Marriage Is Running on Secrets</a></li>
+          <li><a href="/blog/21-brutal-questions-before-i-do.html" class="link-accent underline">21 Brutal Questions to Ask Before You Say &ldquo;I Do&rdquo;</a></li>
+          <li><a href="/blog/ya-mysteries-black-protagonists.html" class="link-accent underline">7 YA Mysteries Featuring Black Protagonists</a></li>
+          <li><a href="/blog/why-some-couples-survive-betrayal.html" class="link-accent underline">Why Some Couples Survive Betrayal&mdash;and Some Don&rsquo;t</a></li>
+          <li><a href="/blog/family-secrets-in-fiction.html" class="link-accent underline">Family Secrets in Fiction: Why We Can&rsquo;t Look Away</a></li>
+          <li><a href="/blog/long-lost-siblings-surprise-adoptions-in-literature.html" class="link-accent underline">Long-Lost Siblings &amp; Surprise Adoptions in Literature</a></li>
           <li><a href="/blog/premonitions-intuition-solving-disappearances.html" class="link-accent underline">Premonitions &amp; Intuition in Missing‑Person YA Thrillers</a></li>
           <li><a href="/blog/real-life-cases-missing-girls-of-color.html" class="link-accent underline">Real-Life Cases of Missing Girls of Color</a></li>
           <li><a href="/blog/african-american-ya-thrillers.html" class="link-accent underline">Top African‑American YA Thrillers: Missing Girls &amp; Mystery</a></li>

--- a/blog/long-lost-siblings-surprise-adoptions-in-literature.html
+++ b/blog/long-lost-siblings-surprise-adoptions-in-literature.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Long-Lost Siblings & Surprise Adoptions in Literature</title>
+  <meta name="description" content="Why long-lost siblings and surprise adoptions hit hard—identity, belonging, and the way one reveal rewrites everything that came before.">
+  <link rel="canonical" href="https://coreyljohnson.com/blog/long-lost-siblings-surprise-adoptions-in-literature">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --ink: #e5e7eb;
+      --navy: #1e3a8a;
+      --navy-700: #2743a0;
+      --page: #0f172a;
+      --subtle: #0b1220;
+    }
+
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: 'Inter', sans-serif;
+      background: var(--page);
+      color: #cbd5e1;
+    }
+
+    h1, h2, h3, h4 { color: var(--ink); }
+
+    .card {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      border-radius: 0.75rem;
+      color: #cbd5e1;
+    }
+
+    .link-accent { color: #93c5fd; }
+    .link-accent:hover { color: #bfdbfe; }
+  </style>
+</head>
+<body class="font-sans antialiased">
+  <header class="backdrop-blur-md sticky top-0 z-10" style="background: rgba(11,18,32,0.7); box-shadow: 0 1px 0 rgba(255,255,255,0.06);">
+    <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+      <a href="/index.html" class="text-2xl font-bold" style="color: var(--ink);">Corey L. Johnson</a>
+      <nav class="space-x-6 hidden md:block">
+        <a href="/index.html#books" class="hover:underline link-accent">Books</a>
+        <a href="/index.html#about" class="hover:underline link-accent">About</a>
+        <a href="/blog/index.html" class="hover:underline link-accent">Blog</a>
+        <a href="/index.html#contact" class="hover:underline link-accent">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container mx-auto px-4 py-12">
+    <article class="max-w-3xl mx-auto card p-8 md:p-10">
+      <h1 class="text-4xl font-bold mb-6">Long-Lost Siblings &amp; Surprise Adoptions in Literature</h1>
+      <p class="mb-4">Identity is a fault line. When a reveal lands&mdash;new sibling, hidden adoption&mdash;the ground shifts. Love has to grow new roots or crack down the middle.</p>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">Why These Twists Work</h2>
+      <ol class="list-decimal pl-6 space-y-3">
+        <li><strong>They rewrite history:</strong> The past means something new.</li>
+        <li><strong>They redraw alliances:</strong> &ldquo;Us&rdquo; and &ldquo;them&rdquo; get renegotiated.</li>
+        <li><strong>They force forward motion:</strong> Belonging must be rebuilt.</li>
+      </ol>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">Reads You Might Love</h2>
+      <p class="mb-2">Southern drama with secrets and second chances:</p>
+      <p class="mb-2">👉 <a href="https://a.co/d/bIOYPL0" target="_blank" rel="noopener" class="link-accent underline"><em>The Grass Is Always Greener</em> &mdash; Amazon</a></p>
+      <p class="mb-2">Small-town YA suspense with a relentless search for truth:</p>
+      <p class="mb-0">👉 <a href="https://a.co/d/cUCeKhh" target="_blank" rel="noopener" class="link-accent underline"><em>They Never Came Home</em> &mdash; Amazon</a></p>
+      <p class="mt-4">See all books on the <a href="/index.html#books" class="link-accent underline">Books page</a>.</p>
+    </article>
+  </main>
+
+  <footer class="py-8" style="background: rgba(11,18,32,0.9);">
+    <div class="container mx-auto px-4 text-center text-slate-300">
+      <p>&copy; <span id="year"></span> Corey L. Johnson. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/blog/posts.json
+++ b/blog/posts.json
@@ -1,5 +1,47 @@
 [
   {
+    "slug": "character-deep-dive-malik-thompson",
+    "title": "Character Deep Dive: Malik Thompson",
+    "excerpt": "Meet Malik Thompson, the sharp, loyal teen who drives They Never Came Home and refuses to let buried truths stay hidden.",
+    "href": "blog/character-deep-dive-malik-thompson.html"
+  },
+  {
+    "slug": "10-signs-your-marriage-is-running-on-secrets",
+    "title": "10 Signs Your Marriage Is Running on Secrets",
+    "excerpt": "Silence, half-answers, and hidden receipts add up fast—spot the ten warning signs and learn how to name the truth before trust snaps.",
+    "href": "blog/10-signs-your-marriage-is-running-on-secrets.html"
+  },
+  {
+    "slug": "21-brutal-questions-before-i-do",
+    "title": "21 Brutal Questions to Ask Before You Say 'I Do'",
+    "excerpt": "Protect your vow by answering the hard questions about money, loyalty, family, and faith long before you walk down the aisle.",
+    "href": "blog/21-brutal-questions-before-i-do.html"
+  },
+  {
+    "slug": "ya-mysteries-black-protagonists",
+    "title": "7 YA Mysteries Featuring Black Protagonists",
+    "excerpt": "Build your TBR with seven high-stakes mysteries where Black teens take the lead and refuse to stop digging for the truth.",
+    "href": "blog/ya-mysteries-black-protagonists.html"
+  },
+  {
+    "slug": "why-some-couples-survive-betrayal",
+    "title": "Why Some Couples Survive Betrayal—and Some Don't",
+    "excerpt": "When trust breaks, some marriages rebuild and others can't—here's what healing requires and when it's wise to walk away.",
+    "href": "blog/why-some-couples-survive-betrayal.html"
+  },
+  {
+    "slug": "family-secrets-in-fiction",
+    "title": "Family Secrets in Fiction: Why We Can't Look Away",
+    "excerpt": "Explore how hidden motives, ticking clocks, and truth-telling fuel the most compelling family dramas and thrillers.",
+    "href": "blog/family-secrets-in-fiction.html"
+  },
+  {
+    "slug": "long-lost-siblings-surprise-adoptions-in-literature",
+    "title": "Long-Lost Siblings & Surprise Adoptions in Literature",
+    "excerpt": "Discover why reunion twists rock a story's foundation and where to find novels that rebuild belonging after the reveal.",
+    "href": "blog/long-lost-siblings-surprise-adoptions-in-literature.html"
+  },
+  {
     "slug": "premonitions-intuition-solving-disappearances",
     "title": "Premonitions & Intuition in Missing‑Person YA Thrillers",
     "excerpt": "Explore how supernatural gifts and gut instincts drive YA mysteries about missing friends. Learn about premonition‑based thrillers and why diverse voices matter.",

--- a/blog/premonitions-intuition-solving-disappearances.html
+++ b/blog/premonitions-intuition-solving-disappearances.html
@@ -10,30 +10,51 @@
   <!-- Google Font -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <style>
+    :root {
+      --ink: #e5e7eb;
+      --navy: #1e3a8a;
+      --navy-700: #2743a0;
+      --page: #0f172a;
+      --subtle: #0b1220;
+    }
+
+    html { scroll-behavior: smooth; }
     body {
       font-family: 'Inter', sans-serif;
+      background: var(--page);
+      color: #cbd5e1;
     }
-    html {
-      scroll-behavior: smooth;
+
+    h1, h2, h3, h4 { color: var(--ink); }
+
+    .card {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      border-radius: 0.75rem;
+      color: #cbd5e1;
     }
+
+    .link-accent { color: #93c5fd; }
+    .link-accent:hover { color: #bfdbfe; }
   </style>
 </head>
-<body class="bg-gray-50 text-gray-800">
+<body class="font-sans antialiased">
   <!-- Navigation -->
-  <header class="bg-white/80 backdrop-blur-md shadow-md sticky top-0 z-10">
+  <header class="backdrop-blur-md sticky top-0 z-10" style="background: rgba(11,18,32,0.7); box-shadow: 0 1px 0 rgba(255,255,255,0.06);">
     <div class="container mx-auto px-4 py-4 flex justify-between items-center">
-      <a href="/index.html" class="text-2xl font-bold text-gray-800">Corey L. Johnson</a>
+      <a href="/index.html" class="text-2xl font-bold" style="color: var(--ink);">Corey L. Johnson</a>
       <nav class="space-x-6 hidden md:block">
-        <a href="/index.html#books" class="text-gray-700 hover:text-gray-900 transition-colors">Books</a>
-        <a href="/index.html#about" class="text-gray-700 hover:text-gray-900 transition-colors">About</a>
-        <a href="/index.html#blog" class="text-gray-700 hover:text-gray-900 transition-colors">Blog</a>
-        <a href="/index.html#contact" class="text-gray-700 hover:text-gray-900 transition-colors">Contact</a>
+        <a href="/index.html#books" class="hover:underline link-accent">Books</a>
+        <a href="/index.html#about" class="hover:underline link-accent">About</a>
+        <a href="/blog/index.html" class="hover:underline link-accent">Blog</a>
+        <a href="/index.html#contact" class="hover:underline link-accent">Contact</a>
       </nav>
     </div>
   </header>
 
   <main class="container mx-auto px-4 py-12">
-    <article class="max-w-3xl mx-auto">
+    <article class="max-w-3xl mx-auto card p-8 md:p-10">
       <h1 class="text-4xl font-bold mb-6">Premonitions &amp; Intuition: Solving Disappearances in YA Thrillers</h1>
       <p class="mb-4">What if your instincts could lead you to the truth? Many young adult thrillers lean on classic detective work—magnifying glasses, hidden clues and suspects with shaky alibis. But a growing subgenre blends mystery with a touch of the supernatural, giving protagonists abilities that border on premonition. These stories don’t just entertain; they explore how gut feelings and uncanny gifts can become tools of survival, especially when the missing are girls of color.</p>
       <p class="mb-4">Intuition isn’t merely a mystical plot device. Research into human cognition shows that “gut feelings” often stem from subconscious pattern recognition. In fiction, heightened intuition provides a metaphor for the ways marginalized communities sense danger before others do. For Black teens, hyper‑awareness is a survival skill—one that becomes life‑saving in thrillers where institutions fall short.</p>
@@ -73,9 +94,9 @@
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">Calls to action</h2>
       <ul class="list-disc pl-5 mb-4">
-        <li class="mb-2">Dive into a blend of mystery and intuition by reading Corey L. Johnson’s <a href="https://a.co/d/cVwd3TI" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline hover:text-blue-800"><em>They Never Came Home</em></a>.</li>
-        <li class="mb-2">Join our community of mystery lovers and get exclusive previews by signing up for the <a href="/index.html#contact" class="text-blue-600 underline hover:text-blue-800">newsletter</a>.</li>
-        <li class="mb-2">Support diverse storytelling across genres by picking up <a href="https://a.co/d/93FOaLR" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline hover:text-blue-800"><em>The Grass Is Always Greener</em></a>, a novel about faith, family and second chances.</li>
+        <li class="mb-2">Dive into a blend of mystery and intuition by reading Corey L. Johnson’s <a href="https://a.co/d/cVwd3TI" target="_blank" rel="noopener noreferrer" class="link-accent underline hover:underline"><em>They Never Came Home</em></a>.</li>
+        <li class="mb-2">Join our community of mystery lovers and get exclusive previews by signing up for the <a href="/index.html#contact" class="link-accent underline hover:underline">newsletter</a>.</li>
+        <li class="mb-2">Support diverse storytelling across genres by picking up <a href="https://a.co/d/93FOaLR" target="_blank" rel="noopener noreferrer" class="link-accent underline hover:underline"><em>The Grass Is Always Greener</em></a>, a novel about faith, family and second chances.</li>
       </ul>
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">Image suggestions</h2>
@@ -85,15 +106,15 @@
       <p class="mb-4">4. <strong>A community search party with flashlights</strong> looking for a missing person. <em>Alt text:</em> “Group of volunteers searching with flashlights at night.”</p>
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">What to read next</h2>
-      <p class="mb-4">For more on intuition and justice, browse our <a href="/index.html#books" class="text-blue-600 underline hover:text-blue-800">Books</a> page and discover stories that blend mystery with social insight. Every time you choose a diverse title, you help ensure the future of inclusive YA fiction.</p>
+      <p class="mb-4">For more on intuition and justice, browse our <a href="/index.html#books" class="link-accent underline hover:underline">Books</a> page and discover stories that blend mystery with social insight. Every time you choose a diverse title, you help ensure the future of inclusive YA fiction.</p>
 
-      <p class="text-sm text-gray-500">Note: This article is for informational and promotional purposes. Some links may be affiliate links.</p>
+      <p class="text-sm text-slate-400">Note: This article is for informational and promotional purposes. Some links may be affiliate links.</p>
     </article>
   </main>
 
   <!-- Footer -->
-  <footer class="bg-gray-900 text-gray-200 py-8">
-    <div class="container mx-auto px-4 text-center">
+  <footer class="py-8" style="background: rgba(11,18,32,0.9);">
+    <div class="container mx-auto px-4 text-center text-slate-300">
       <p>&copy; <span id="year"></span> Corey L. Johnson. All rights reserved.</p>
     </div>
   </footer>

--- a/blog/real-life-cases-missing-girls-of-color.html
+++ b/blog/real-life-cases-missing-girls-of-color.html
@@ -10,30 +10,51 @@
   <!-- Google Font -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <style>
+    :root {
+      --ink: #e5e7eb;
+      --navy: #1e3a8a;
+      --navy-700: #2743a0;
+      --page: #0f172a;
+      --subtle: #0b1220;
+    }
+
+    html { scroll-behavior: smooth; }
     body {
       font-family: 'Inter', sans-serif;
+      background: var(--page);
+      color: #cbd5e1;
     }
-    html {
-      scroll-behavior: smooth;
+
+    h1, h2, h3, h4 { color: var(--ink); }
+
+    .card {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      border-radius: 0.75rem;
+      color: #cbd5e1;
     }
+
+    .link-accent { color: #93c5fd; }
+    .link-accent:hover { color: #bfdbfe; }
   </style>
 </head>
-<body class="bg-gray-50 text-gray-800">
+<body class="font-sans antialiased">
   <!-- Navigation -->
-  <header class="bg-white/80 backdrop-blur-md shadow-md sticky top-0 z-10">
+  <header class="backdrop-blur-md sticky top-0 z-10" style="background: rgba(11,18,32,0.7); box-shadow: 0 1px 0 rgba(255,255,255,0.06);">
     <div class="container mx-auto px-4 py-4 flex justify-between items-center">
-      <a href="/index.html" class="text-2xl font-bold text-gray-800">Corey L. Johnson</a>
+      <a href="/index.html" class="text-2xl font-bold" style="color: var(--ink);">Corey L. Johnson</a>
       <nav class="space-x-6 hidden md:block">
-        <a href="/index.html#books" class="text-gray-700 hover:text-gray-900 transition-colors">Books</a>
-        <a href="/index.html#about" class="text-gray-700 hover:text-gray-900 transition-colors">About</a>
-        <a href="/index.html#blog" class="text-gray-700 hover:text-gray-900 transition-colors">Blog</a>
-        <a href="/index.html#contact" class="text-gray-700 hover:text-gray-900 transition-colors">Contact</a>
+        <a href="/index.html#books" class="hover:underline link-accent">Books</a>
+        <a href="/index.html#about" class="hover:underline link-accent">About</a>
+        <a href="/blog/index.html" class="hover:underline link-accent">Blog</a>
+        <a href="/index.html#contact" class="hover:underline link-accent">Contact</a>
       </nav>
     </div>
   </header>
 
   <main class="container mx-auto px-4 py-12">
-    <article class="max-w-3xl mx-auto">
+    <article class="max-w-3xl mx-auto card p-8 md:p-10">
       <h1 class="text-4xl font-bold mb-6">Real‑Life Cases of Missing Girls of Color</h1>
       <p class="mb-4">Fictional mysteries often begin with a disappearance and end with answers. In real life, families of missing girls of color rarely get closure—or attention. A glance at police bulletins reveals that thousands of Black and Brown girls go missing every year, yet their stories barely make headlines. This imbalance echoes the long history of erasing Black children from storytelling. In the early 1960s, critic Nancy Larrick documented that out of more than 5,000 children’s books reviewed, only 40 featured contemporary African‑American characters【992448684961857†L395-L404】. Today, while representation in publishing has improved, media coverage of missing Black girls remains woefully lacking.</p>
       <p class="mb-4">The term “missing white woman syndrome” describes how news outlets devote disproportionate attention to cases involving white women and girls, while similar disappearances of women of color receive little coverage. This disparity has deadly consequences. Publicity can bring resources, tips and pressure on law enforcement; its absence leaves families to search alone. Organizations like the Black and Missing Foundation (BAMFI) report that missing persons cases for Black girls often stall without the media spotlight. Families are told their loved ones “probably ran away” or “will turn up.”</p>
@@ -58,7 +79,7 @@
       </ul>
       <p class="mb-4">Above all, listen to families. They are the experts on their loved ones and the leaders of search efforts. Amplify their voices rather than speaking over them.</p>
 
-      <h2 class="text-3xl font-semibold mb-4 mt-10">Frequently Asked Questions</h3>
+      <h2 class="text-3xl font-semibold mb-4 mt-10">Frequently Asked Questions</h2>
       <h3 class="text-2xl font-semibold mb-2 mt-6">1. Why do missing girls of color get less media coverage?</h3>
       <p class="mb-4">Implicit bias plays a major role. Newsrooms often assume their audience relates more to white victims, leading to disproportionate coverage. There’s also a stereotype that Black girls are more likely to run away or engage in risky behavior, which reduces urgency. Advocates urge journalists to question these assumptions.</p>
       <h3 class="text-2xl font-semibold mb-2 mt-6">2. What organizations focus on missing Black children?</h3>
@@ -74,10 +95,10 @@
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">Calls to action</h2>
       <ul class="list-disc pl-5 mb-4">
-        <li class="mb-2">Read fiction that highlights these issues, starting with Corey L. Johnson’s <a href="https://a.co/d/cVwd3TI" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline hover:text-blue-800"><em>They Never Came Home</em></a>.</li>
-        <li class="mb-2">Join our mailing list for updates on new books and resources by signing up through the <a href="/index.html#contact" class="text-blue-600 underline hover:text-blue-800">newsletter form</a>.</li>
+        <li class="mb-2">Read fiction that highlights these issues, starting with Corey L. Johnson’s <a href="https://a.co/d/cVwd3TI" target="_blank" rel="noopener noreferrer" class="link-accent underline hover:underline"><em>They Never Came Home</em></a>.</li>
+        <li class="mb-2">Join our mailing list for updates on new books and resources by signing up through the <a href="/index.html#contact" class="link-accent underline hover:underline">newsletter form</a>.</li>
         <li class="mb-2">Support the families of missing girls of color by donating to organizations like BAMFI and attending local awareness events.</li>
-        <li class="mb-2">Explore more of Corey’s writing—his contemporary novel <a href="https://a.co/d/93FOaLR" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline hover:text-blue-800"><em>The Grass Is Always Greener</em></a> tackles family secrets and forgiveness.</li>
+        <li class="mb-2">Explore more of Corey’s writing—his contemporary novel <a href="https://a.co/d/93FOaLR" target="_blank" rel="noopener noreferrer" class="link-accent underline hover:underline"><em>The Grass Is Always Greener</em></a> tackles family secrets and forgiveness.</li>
       </ul>
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">Image suggestions</h2>
@@ -87,15 +108,15 @@
       <p class="mb-4">4. <strong>Map with highlighted search areas</strong>. <em>Alt text:</em> “Map with circles and pins marking areas searched for a missing person.”</p>
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">What to read next</h2>
-      <p class="mb-4">For more insights into how fiction and reality intersect, visit our <a href="/index.html#books" class="text-blue-600 underline hover:text-blue-800">Books</a> page and read about stories that center marginalized voices. When we pay attention to every missing child—not just the ones who look like us—we move closer to justice.</p>
+      <p class="mb-4">For more insights into how fiction and reality intersect, visit our <a href="/index.html#books" class="link-accent underline hover:underline">Books</a> page and read about stories that center marginalized voices. When we pay attention to every missing child—not just the ones who look like us—we move closer to justice.</p>
 
-      <p class="text-sm text-gray-500">Note: This article is for informational and promotional purposes. Some links may be affiliate links.</p>
+      <p class="text-sm text-slate-400">Note: This article is for informational and promotional purposes. Some links may be affiliate links.</p>
     </article>
   </main>
 
   <!-- Footer -->
-  <footer class="bg-gray-900 text-gray-200 py-8">
-    <div class="container mx-auto px-4 text-center">
+  <footer class="py-8" style="background: rgba(11,18,32,0.9);">
+    <div class="container mx-auto px-4 text-center text-slate-300">
       <p>&copy; <span id="year"></span> Corey L. Johnson. All rights reserved.</p>
     </div>
   </footer>

--- a/blog/why-representation-matters-ya-thrillers.html
+++ b/blog/why-representation-matters-ya-thrillers.html
@@ -10,30 +10,51 @@
   <!-- Google Font -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <style>
+    :root {
+      --ink: #e5e7eb;
+      --navy: #1e3a8a;
+      --navy-700: #2743a0;
+      --page: #0f172a;
+      --subtle: #0b1220;
+    }
+
+    html { scroll-behavior: smooth; }
     body {
       font-family: 'Inter', sans-serif;
+      background: var(--page);
+      color: #cbd5e1;
     }
-    html {
-      scroll-behavior: smooth;
+
+    h1, h2, h3, h4 { color: var(--ink); }
+
+    .card {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      border-radius: 0.75rem;
+      color: #cbd5e1;
     }
+
+    .link-accent { color: #93c5fd; }
+    .link-accent:hover { color: #bfdbfe; }
   </style>
 </head>
-<body class="bg-gray-50 text-gray-800">
+<body class="font-sans antialiased">
   <!-- Navigation -->
-  <header class="bg-white/80 backdrop-blur-md shadow-md sticky top-0 z-10">
+  <header class="backdrop-blur-md sticky top-0 z-10" style="background: rgba(11,18,32,0.7); box-shadow: 0 1px 0 rgba(255,255,255,0.06);">
     <div class="container mx-auto px-4 py-4 flex justify-between items-center">
-      <a href="/index.html" class="text-2xl font-bold text-gray-800">Corey L. Johnson</a>
+      <a href="/index.html" class="text-2xl font-bold" style="color: var(--ink);">Corey L. Johnson</a>
       <nav class="space-x-6 hidden md:block">
-        <a href="/index.html#books" class="text-gray-700 hover:text-gray-900 transition-colors">Books</a>
-        <a href="/index.html#about" class="text-gray-700 hover:text-gray-900 transition-colors">About</a>
-        <a href="/index.html#blog" class="text-gray-700 hover:text-gray-900 transition-colors">Blog</a>
-        <a href="/index.html#contact" class="text-gray-700 hover:text-gray-900 transition-colors">Contact</a>
+        <a href="/index.html#books" class="hover:underline link-accent">Books</a>
+        <a href="/index.html#about" class="hover:underline link-accent">About</a>
+        <a href="/blog/index.html" class="hover:underline link-accent">Blog</a>
+        <a href="/index.html#contact" class="hover:underline link-accent">Contact</a>
       </nav>
     </div>
   </header>
 
   <main class="container mx-auto px-4 py-12">
-    <article class="max-w-3xl mx-auto">
+    <article class="max-w-3xl mx-auto card p-8 md:p-10">
       <h1 class="text-4xl font-bold mb-6">Why Representation Matters in YA Thrillers</h1>
       <p class="mb-4">Young adult thrillers are built on high stakes and cliffhangers. They keep readers guessing with twists and turns and missing‑person mysteries. But for far too long, these stories have been missing something vital: the faces and voices of Black teens. In 1965, children’s literature critic Nancy Larrick reviewed more than 5,000 books published in the early 1960s and found only <strong>40</strong> that featured contemporary African‑American characters【992448684961857†L395-L404】. That startling statistic helped spark a movement for inclusive publishing, yet in the decades since, progress has been slow. Black protagonists remain rare in YA thriller sections and missing‑girl narratives rarely center Black girls, even though real‑world cases reveal a different story.</p>
       <p class="mb-4">Representation isn’t just a buzzword; it shapes how readers see themselves and others. When YA thrillers feature Black characters as heroes, investigators and survivors, they normalize the idea that Black lives are worthy of the spotlight—and of rescue. Inclusive stories help every reader understand that danger and courage cross racial lines. They also challenge harmful media tropes that ignore missing girls of color or cast them as suspects rather than victims. By filling shelves with diverse thrillers, publishers and authors empower young readers of color to see themselves reflected in stories of resilience and justice.</p>
@@ -73,9 +94,9 @@
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">Calls to action</h2>
       <ul class="list-disc pl-5 mb-4">
-        <li class="mb-2">Support inclusive storytelling by <a href="https://a.co/d/cVwd3TI" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline hover:text-blue-800">reading <em>They Never Came Home</em></a> and sharing it with friends.</li>
-        <li class="mb-2">Stay informed about new releases and discussion guides by joining Corey L. Johnson’s <a href="/index.html#contact" class="text-blue-600 underline hover:text-blue-800">newsletter</a>.</li>
-        <li class="mb-2">Explore family dramas and redemption arcs in Corey’s contemporary novel <a href="https://a.co/d/93FOaLR" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline hover:text-blue-800"><em>The Grass Is Always Greener</em></a>.</li>
+        <li class="mb-2">Support inclusive storytelling by <a href="https://a.co/d/cVwd3TI" target="_blank" rel="noopener noreferrer" class="link-accent underline hover:underline">reading <em>They Never Came Home</em></a> and sharing it with friends.</li>
+        <li class="mb-2">Stay informed about new releases and discussion guides by joining Corey L. Johnson’s <a href="/index.html#contact" class="link-accent underline hover:underline">newsletter</a>.</li>
+        <li class="mb-2">Explore family dramas and redemption arcs in Corey’s contemporary novel <a href="https://a.co/d/93FOaLR" target="_blank" rel="noopener noreferrer" class="link-accent underline hover:underline"><em>The Grass Is Always Greener</em></a>.</li>
       </ul>
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">Image suggestions</h2>
@@ -85,15 +106,15 @@
       <p class="mb-4">4. <strong>Illustrated collage of diverse teen detectives</strong> with magnifying glasses and clues. <em>Alt text:</em> “Illustration of diverse teens working together as detectives.”</p>
 
       <h2 class="text-3xl font-semibold mb-4 mt-10">What to read next</h2>
-      <p class="mb-4">If this article inspired you to diversify your reading, head to our <a href="/index.html#books" class="text-blue-600 underline hover:text-blue-800">Books</a> page for more titles by Corey L. Johnson and recommended authors. Every purchase or library checkout is a vote for more stories that reflect the richness of our world.</p>
+      <p class="mb-4">If this article inspired you to diversify your reading, head to our <a href="/index.html#books" class="link-accent underline hover:underline">Books</a> page for more titles by Corey L. Johnson and recommended authors. Every purchase or library checkout is a vote for more stories that reflect the richness of our world.</p>
 
-      <p class="text-sm text-gray-500">Note: This article is for informational and promotional purposes. Some links may be affiliate links.</p>
+      <p class="text-sm text-slate-400">Note: This article is for informational and promotional purposes. Some links may be affiliate links.</p>
     </article>
   </main>
 
   <!-- Footer -->
-  <footer class="bg-gray-900 text-gray-200 py-8">
-    <div class="container mx-auto px-4 text-center">
+  <footer class="py-8" style="background: rgba(11,18,32,0.9);">
+    <div class="container mx-auto px-4 text-center text-slate-300">
       <p>&copy; <span id="year"></span> Corey L. Johnson. All rights reserved.</p>
     </div>
   </footer>

--- a/blog/why-some-couples-survive-betrayal.html
+++ b/blog/why-some-couples-survive-betrayal.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Why Some Couples Survive Betrayal—and Some Don’t</title>
+  <meta name="description" content="Not all betrayals end marriages. Here’s why some couples rebuild after the break—and why others can’t or shouldn’t. Honest, practical, hopeful.">
+  <link rel="canonical" href="https://coreyljohnson.com/blog/why-some-couples-survive-betrayal">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --ink: #e5e7eb;
+      --navy: #1e3a8a;
+      --navy-700: #2743a0;
+      --page: #0f172a;
+      --subtle: #0b1220;
+    }
+
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: 'Inter', sans-serif;
+      background: var(--page);
+      color: #cbd5e1;
+    }
+
+    h1, h2, h3, h4 { color: var(--ink); }
+
+    .card {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      border-radius: 0.75rem;
+      color: #cbd5e1;
+    }
+
+    .link-accent { color: #93c5fd; }
+    .link-accent:hover { color: #bfdbfe; }
+  </style>
+</head>
+<body class="font-sans antialiased">
+  <header class="backdrop-blur-md sticky top-0 z-10" style="background: rgba(11,18,32,0.7); box-shadow: 0 1px 0 rgba(255,255,255,0.06);">
+    <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+      <a href="/index.html" class="text-2xl font-bold" style="color: var(--ink);">Corey L. Johnson</a>
+      <nav class="space-x-6 hidden md:block">
+        <a href="/index.html#books" class="hover:underline link-accent">Books</a>
+        <a href="/index.html#about" class="hover:underline link-accent">About</a>
+        <a href="/blog/index.html" class="hover:underline link-accent">Blog</a>
+        <a href="/index.html#contact" class="hover:underline link-accent">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container mx-auto px-4 py-12">
+    <article class="max-w-3xl mx-auto card p-8 md:p-10">
+      <h1 class="text-4xl font-bold mb-6">Why Some Couples Survive Betrayal&mdash;and Some Don&rsquo;t</h1>
+      <p class="mb-4">Betrayal doesn&rsquo;t always mean goodbye. It does mean a reckoning. Here&rsquo;s what I&rsquo;ve learned&mdash;from life, and from writing families who fight for grace.</p>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">What Survival Requires</h2>
+      <ul class="list-disc pl-5 space-y-2 mb-6">
+        <li><strong>Full truth:</strong> Not piecemeal, not curated&mdash;whole truth, held gently.</li>
+        <li><strong>Shared purpose:</strong> We aren&rsquo;t fixing image; we&rsquo;re rebuilding trust.</li>
+        <li><strong>Boundaries + time:</strong> Safety first, patience second. Healing isn&rsquo;t a sprint.</li>
+        <li><strong>Repentance, not performance:</strong> Consistent change beats perfect words.</li>
+      </ul>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">When Walking Away Is Wisdom</h2>
+      <ul class="list-disc pl-5 space-y-2 mb-6">
+        <li>Ongoing deceit, blame-shifting, or stonewalling.</li>
+        <li>Emotional or physical harm.</li>
+        <li>No shared vision for the future.</li>
+      </ul>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">Stories That Hold Both Truths</h2>
+      <p class="mb-2">For a Southern family reckoning with secrets and forgiveness:</p>
+      <p class="mb-2">👉 <a href="https://a.co/d/bIOYPL0" target="_blank" rel="noopener" class="link-accent underline"><em>The Grass Is Always Greener</em> &mdash; Amazon</a></p>
+      <p class="mb-2">For a YA thriller about loyalty under pressure:</p>
+      <p class="mb-0">👉 <a href="https://a.co/d/cUCeKhh" target="_blank" rel="noopener" class="link-accent underline"><em>They Never Came Home</em> &mdash; Amazon</a></p>
+      <p class="mt-4">See more on the <a href="/index.html#books" class="link-accent underline">Books page</a>.</p>
+    </article>
+  </main>
+
+  <footer class="py-8" style="background: rgba(11,18,32,0.9);">
+    <div class="container mx-auto px-4 text-center text-slate-300">
+      <p>&copy; <span id="year"></span> Corey L. Johnson. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/blog/ya-mysteries-black-protagonists.html
+++ b/blog/ya-mysteries-black-protagonists.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>7 YA Mysteries Featuring Black Protagonists</title>
+  <meta name="description" content="Seven YA mysteries with Black protagonists—voicey, high-stakes reads for fans of small-town suspense and character-driven thrillers.">
+  <link rel="canonical" href="https://coreyljohnson.com/blog/ya-mysteries-black-protagonists">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --ink: #e5e7eb;
+      --navy: #1e3a8a;
+      --navy-700: #2743a0;
+      --page: #0f172a;
+      --subtle: #0b1220;
+    }
+
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: 'Inter', sans-serif;
+      background: var(--page);
+      color: #cbd5e1;
+    }
+
+    h1, h2, h3, h4 { color: var(--ink); }
+
+    .card {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      border-radius: 0.75rem;
+      color: #cbd5e1;
+    }
+
+    .link-accent { color: #93c5fd; }
+    .link-accent:hover { color: #bfdbfe; }
+  </style>
+</head>
+<body class="font-sans antialiased">
+  <header class="backdrop-blur-md sticky top-0 z-10" style="background: rgba(11,18,32,0.7); box-shadow: 0 1px 0 rgba(255,255,255,0.06);">
+    <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+      <a href="/index.html" class="text-2xl font-bold" style="color: var(--ink);">Corey L. Johnson</a>
+      <nav class="space-x-6 hidden md:block">
+        <a href="/index.html#books" class="hover:underline link-accent">Books</a>
+        <a href="/index.html#about" class="hover:underline link-accent">About</a>
+        <a href="/blog/index.html" class="hover:underline link-accent">Blog</a>
+        <a href="/index.html#contact" class="hover:underline link-accent">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container mx-auto px-4 py-12">
+    <article class="max-w-3xl mx-auto card p-8 md:p-10">
+      <h1 class="text-4xl font-bold mb-6">7 YA Mysteries Featuring Black Protagonists</h1>
+      <p class="mb-4">Looking for twisty, character-driven thrillers with Black teens at the center? Start here.</p>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">Quick Picks</h2>
+      <ol class="list-decimal pl-6 space-y-3">
+        <li><em>They Never Came Home</em> &mdash; Small-town secrets, missing girls, a teen who won&rsquo;t stop asking questions.</li>
+        <li><em>When You Look Like Us</em> (Pamela N. Harris)</li>
+        <li><em>Monday&rsquo;s Not Coming</em> (Tiffany D. Jackson)</li>
+        <li><em>Allegedly</em> (Tiffany D. Jackson)</li>
+        <li><em>The Taking of Jake Livingston</em> (Ryan Douglass)</li>
+        <li><em>Jackal</em> (adult crossover vibes for older YA readers)</li>
+        <li><em>The Forest of Stolen Girls</em> (June Hur) &mdash; historical mystery readers will love</li>
+      </ol>
+
+      <h2 class="text-3xl font-semibold mt-10 mb-4">Want more?</h2>
+      <p class="mb-2">See my <a href="/index.html#books" class="link-accent underline">Books page</a>, or grab a copy below.</p>
+      <p class="mb-2">👉 <a href="https://a.co/d/cUCeKhh" target="_blank" rel="noopener" class="link-accent underline"><em>They Never Came Home</em> &mdash; Amazon</a></p>
+      <p class="mb-0">👉 <a href="https://a.co/d/bIOYPL0" target="_blank" rel="noopener" class="link-accent underline"><em>The Grass Is Always Greener</em> &mdash; Amazon</a></p>
+    </article>
+  </main>
+
+  <footer class="py-8" style="background: rgba(11,18,32,0.9);">
+    <div class="container mx-auto px-4 text-center text-slate-300">
+      <p>&copy; <span id="year"></span> Corey L. Johnson. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
       <nav class="space-x-6 hidden md:block">
         <a href="#books"   class="hover:underline link-accent">Books</a>
         <a href="#about"   class="hover:underline link-accent">About</a>
-        <a href="#blog"    class="hover:underline link-accent">Blog</a>
+        <a href="blog/index.html"    class="hover:underline link-accent">Blog</a>
         <a href="#contact" class="hover:underline link-accent">Contact</a>
       </nav>
     </div>
@@ -141,10 +141,15 @@
 
     <section id="blog" class="py-20 section-alt">
     <div class="container mx-auto px-4">
-      <h2 class="text-4xl font-bold text-center mb-12">From the Blog</h2>
+      <h2 class="text-4xl font-bold text-center mb-6">From the Blog</h2>
+      <div class="max-w-4xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4 mb-10 text-slate-300">
+        <p class="text-center md:text-left">Catch up on Corey’s latest essays, book updates, and behind-the-scenes posts. Prefer a quick list? Browse every article on the dedicated blog page.</p>
+        <a href="blog/index.html" class="inline-flex items-center px-6 py-3 rounded-full font-semibold transition-transform transform hover:-translate-y-0.5 btn-outline">View all posts</a>
+      </div>
 
       <!-- BLOG:START -->
       <div class="grid md:grid-cols-3 gap-10">
+        <!--POST_PLACEHOLDER-->
         <article class="card shadow-lg overflow-hidden p-6 transition duration-300 transform hover:shadow-xl hover:-translate-y-1">
           <h3 class="text-xl font-semibold mb-3">Premonitions &amp; Intuition in Missing‑Person YA Thrillers</h3>
           <p class="mb-4">Explore how supernatural gifts and gut instincts drive YA mysteries about missing friends. Learn about premonition‑based thrillers and why diverse voices matter.</p>

--- a/index.html
+++ b/index.html
@@ -151,33 +151,39 @@
       <div class="grid md:grid-cols-3 gap-10">
         <!--POST_PLACEHOLDER-->
         <article class="card shadow-lg overflow-hidden p-6 transition duration-300 transform hover:shadow-xl hover:-translate-y-1">
-          <h3 class="text-xl font-semibold mb-3">Premonitions &amp; Intuition in Missing‑Person YA Thrillers</h3>
-          <p class="mb-4">Explore how supernatural gifts and gut instincts drive YA mysteries about missing friends. Learn about premonition‑based thrillers and why diverse voices matter.</p>
-          <a href="blog/premonitions-intuition-solving-disappearances.html" class="font-medium">Read More →</a>
+          <h3 class="text-xl font-semibold mb-3">Character Deep Dive: Malik Thompson</h3>
+          <p class="mb-4">Meet the relentless teen at the heart of <em>They Never Came Home</em> and see why his mix of loyalty and intuition keeps the story racing.</p>
+          <a href="blog/character-deep-dive-malik-thompson.html" class="font-medium">Read More →</a>
         </article>
 
         <article class="card shadow-lg overflow-hidden p-6 transition duration-300 transform hover:shadow-xl hover:-translate-y-1">
-          <h3 class="text-xl font-semibold mb-3">Real-Life Cases of Missing Girls of Color</h3>
-          <p class="mb-4">Learn about the crisis of missing girls of color, media bias, and how you can help. Explore Corey L. Johnson’s fiction and real-world resources to take action.</p>
-          <a href="blog/real-life-cases-missing-girls-of-color.html" class="font-medium">Read More →</a>
+          <h3 class="text-xl font-semibold mb-3">10 Signs Your Marriage Is Running on Secrets</h3>
+          <p class="mb-4">Spot the subtle lies, hidden receipts, and silent drift before trust snaps—and learn the first steps back to honesty.</p>
+          <a href="blog/10-signs-your-marriage-is-running-on-secrets.html" class="font-medium">Read More →</a>
         </article>
 
         <article class="card shadow-lg overflow-hidden p-6 transition duration-300 transform hover:shadow-xl hover:-translate-y-1">
-          <h3 class="text-xl font-semibold mb-3">Top African‑American YA Thrillers: Missing Girls &amp; Mystery</h3>
-          <p class="mb-4">Explore gripping YA thrillers featuring Black protagonists and missing girls. Learn why representation matters and discover Corey L. Johnson’s new YA thriller &#39;They Never Came Home&#39;.</p>
-          <a href="blog/african-american-ya-thrillers.html" class="font-medium">Read More →</a>
+          <h3 class="text-xl font-semibold mb-3">21 Brutal Questions to Ask Before You Say “I Do”</h3>
+          <p class="mb-4">Print the hard questions about money, faith, and loyalty so you can build a marriage that lasts beyond the aisle.</p>
+          <a href="blog/21-brutal-questions-before-i-do.html" class="font-medium">Read More →</a>
         </article>
 
         <article class="card shadow-lg overflow-hidden p-6 transition duration-300 transform hover:shadow-xl hover:-translate-y-1">
-          <h3 class="text-xl font-semibold mb-3">Why Representation Matters in YA Thrillers</h3>
-          <p class="mb-4">Unpack why diversity in YA thrillers matters. Discover how inclusive storytelling empowers readers and explore Corey L. Johnson’s work featuring Black protagonists.</p>
-          <a href="blog/why-representation-matters-ya-thrillers.html" class="font-medium">Read More →</a>
+          <h3 class="text-xl font-semibold mb-3">7 YA Mysteries Featuring Black Protagonists</h3>
+          <p class="mb-4">Fill your TBR with gripping thrillers where Black teens take the lead, chase the truth, and refuse to back down.</p>
+          <a href="blog/ya-mysteries-black-protagonists.html" class="font-medium">Read More →</a>
         </article>
 
         <article class="card shadow-lg overflow-hidden p-6 transition duration-300 transform hover:shadow-xl hover:-translate-y-1">
-          <h3 class="text-xl font-semibold mb-3">Writing Suspense Without Gore: Building Tension Through Atmosphere</h3>
-          <p class="mb-4">Learn how to craft nail‑biting suspense without graphic violence. Discover techniques for atmosphere, pacing and character, and see how Corey L. Johnson uses them in his novels.</p>
-          <a href="blog/how-to-write-suspense-without-gore-11-05-09-am.html" class="font-medium">Read More →</a>
+          <h3 class="text-xl font-semibold mb-3">Why Some Couples Survive Betrayal—and Some Don’t</h3>
+          <p class="mb-4">Understand what real repair requires after a break in trust—and when walking away is the bravest choice.</p>
+          <a href="blog/why-some-couples-survive-betrayal.html" class="font-medium">Read More →</a>
+        </article>
+
+        <article class="card shadow-lg overflow-hidden p-6 transition duration-300 transform hover:shadow-xl hover:-translate-y-1">
+          <h3 class="text-xl font-semibold mb-3">Family Secrets in Fiction: Why We Can’t Look Away</h3>
+          <p class="mb-4">Explore how hidden motives and overdue truths power the most unforgettable family dramas and thrillers.</p>
+          <a href="blog/family-secrets-in-fiction.html" class="font-medium">Read More →</a>
         </article>
       </div>
       <!-- BLOG:END -->


### PR DESCRIPTION
## Summary
- add a blog landing page that lists every article dynamically from `posts.json` with the same dark styling as the homepage
- update the homepage navigation and blog section to point visitors to the full blog listing via a prominent call to action
- restyle all existing blog detail pages to share the site’s dark palette, typography, and link treatments for a seamless reading experience

## Testing
- not run (static site changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d9cba5e0d483249cc13e55058b5031